### PR TITLE
Opening doors enhanced

### DIFF
--- a/src/components/VmsList/Vm.js
+++ b/src/components/VmsList/Vm.js
@@ -13,18 +13,19 @@ import { selectVmDetail } from '../../actions'
 /**
  * Single icon-card in the list
  */
-const Vm = ({ vm, icons, onSelectVm }) => {
+const Vm = ({ vm, icons, onSelectVm, visibility }) => {
   const state = vm.get('status')
 
   const iconId = vm.getIn(['icons', 'large', 'id'])
   const icon = icons.get(iconId)
+  const isSelected = vm.get('id') === visibility.get('selectedVmDetail')
 
   // TODO: improve the card flip:
   // TODO: https://davidwalsh.name/css-flip
   // TODO: http://tympanus.net/codrops/2013/12/18/perspective-page-view-navigation/
   // TODO: https://desandro.github.io/3dtransforms/docs/card-flip.html
   return (
-    <div className='col-xs-12 col-sm-6 col-md-4 col-lg-3'>
+    <div className={`col-xs-12 col-sm-6 col-md-4 col-lg-3 ${isSelected ? style['selectedVm'] : ''}`}>
       <div className='card-pf card-pf-view card-pf-view-select card-pf-view-single-select'>
         <div className='card-pf-body'>
           <div className='card-pf-top-element' onClick={onSelectVm}>
@@ -49,11 +50,13 @@ Vm.propTypes = {
   vm: PropTypes.object.isRequired,
   icons: PropTypes.object.isRequired,
   onSelectVm: PropTypes.func.isRequired,
+  visibility: PropTypes.object.isRequired,
 }
 
 export default connect(
   (state) => ({
     icons: state.icons,
+    visibility: state.visibility,
   }),
   (dispatch, { vm }) => ({
     onSelectVm: () => dispatch(selectVmDetail({ vmId: vm.get('id') })),

--- a/src/components/VmsList/Vms.js
+++ b/src/components/VmsList/Vms.js
@@ -8,20 +8,27 @@ import { closeDetail } from '../../actions'
 
 const Vms = ({ vms, visibility, onCloseDetail }) => {
   const isDetailVisible = visibility.get('selectedVmDetail') || visibility.get('showOptions')
-//  const containerClass = `container-fluid container-cards-pf ${style['movable-left']} ${isDetailVisible ? style['moved-left'] : ''}`
   const containerClass = ['container-fluid', 'container-cards-pf', style['movable-left'],
-    isDetailVisible ? style['moved-left'] : undefined].join(' ')
+    isDetailVisible ? style['moved-left'] : ''].join(' ')
 
-  // The overlayingDiv disables actions of inner components and grays-out the list
-  const overlayingDiv = isDetailVisible ? (<div className={style['overlay']} onClick={onCloseDetail} />) : ''
+  const closeDetail = isDetailVisible
+    ? (event) => {
+      onCloseDetail()
+      event.stopPropagation()
+    }
+    : undefined
 
   return (
-    <div className={containerClass}>
-      <div className='row row-cards-pf'>
-        {vms.get('vms').toList().map(vm =>
-          <Vm vm={vm} key={vm.get('id')} />)}
+    <div onClickCapture={closeDetail}>
+      <div className={containerClass}>
+        <div className={style['scrollingWrapper']}>
+          <div className='row row-cards-pf'>
+            {vms.get('vms').toList().map(vm =>
+              <Vm vm={vm} key={vm.get('id')} />)}
+          </div>
+          <div className={style['overlay']} />
+        </div>
       </div>
-      {overlayingDiv}
     </div>
   )
 }

--- a/src/components/VmsList/style.css
+++ b/src/components/VmsList/style.css
@@ -1,11 +1,15 @@
 .movable-left { /* general transition properties */
-    transition: transform 0.6s;
+    transition: all 0.6s;
     transform-origin: 0 50%;
     transition-timing-function: ease-out;
+
+    overflow: auto;
+    height: calc(100vh - 49px);
 }
 
 .moved-left { /* altered state */
     transform: perspective(1000px) rotateY(50deg);
+    overflow: hidden; /* scrolling disabled */
 }
 
 .card-pf-icon {
@@ -22,18 +26,32 @@
     width: inherit;
 }
 
+.scrollingWrapper {
+    position: relative;
+}
+
 .overlay {
+    transition: all 0.6s;
     z-index: 10;
     width: 100%;
     height: 100%;
     position: absolute;
     top: 0px;
-    opacity: 0.3;
+    opacity: 0;
     background-color: lightgrey;
-    border-style: solid;
+    display: none;
+}
+
+.moved-left .overlay {
+    display: block;
+    opacity: 0.4;
 }
 
 .vm-name {
     font-size: 0.8em;
     min-height: 2.5em;
+}
+
+.selectedVm {
+    z-index: 20;
 }


### PR DESCRIPTION
* only visible part of screen is opened (not whole list of vms)
* border of grey overlay was removed, since the overlay covers whole
  list of vms
* clicking on the left side of the page (door area) causes door to close
* selected vm is highlighted by not being hidden under grey overlay
  (z-index schema when vm detail is snown: 0 - list of vms, 10 -
  overlay, 20 - selected vm)