### PR TITLE
'npm run watch' added

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "cd showcase && webpack-dev-server --inline --open",
     "build": "webpack",
+    "build:watch": "webpack --watch",
     "prebuild": "npm run test",
     "pretest": "eslint webpack.config.js src showcase samples/**/src",
     "test": "jest --no-watchman",


### PR DESCRIPTION
It works nicely `npm start` in userportal project. It allows to just
code and check results, not being bothered by build process.